### PR TITLE
Add error handling for JSON.parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ node_modules
 
 # PhpStorm
 .idea
+
+.vscode

--- a/lib/icws.js
+++ b/lib/icws.js
@@ -58,7 +58,10 @@ ICWS.prototype = {
 
             return MyRequest.request(method, url, headers, JSON.stringify(body)).then(function(result) {
                 //Parse body as json for easier handling
-                result.body = JSON.parse(result.body);
+                
+                // JSON.parse might fail.
+                try { result.body = JSON.parse(result.body); }
+                catch (err) { return reject(err); }
                 
                 /*Check status code and if not 2xx try with an alternate host (chech if alternate host exists)
                 Also a counter (tryCounter) is used to keep track of numbers of alternate host attempts and

--- a/lib/icwsAuth.js
+++ b/lib/icwsAuth.js
@@ -22,7 +22,8 @@ ICWSAuth.prototype = {
                 'userID': that.username,
                 'password': that.password
             })).then(function(result) {
-                result.body = JSON.parse(result.body);
+                try { result.body = JSON.parse(result.body); }
+                catch (err) { return reject(err); }
                 
                 that.cookies = result.response.headers['set-cookie'];
                 that.token = result.body.csrfToken;

--- a/lib/powerBi.js
+++ b/lib/powerBi.js
@@ -15,8 +15,13 @@ PowerBi.prototype = {
                 'Authorization': 'Bearer ' + that.token,
                 'Content-Type': 'application/json'
             }, JSON.stringify(data)).then(function(result) {
-                if(result.body.length > 0 && typeof JSON.parse(result.body).error != 'undefined') {
-                    reject(JSON.parse(result.body).error);
+                
+                var parsed; // JSON.parse might fail.
+                try { parsed = JSON.parse(result.body); }
+                catch (err) { return reject(err); }
+                
+                if(result.body.length > 0 && typeof parsed.error != 'undefined') {
+                    reject(parsed.error);
                 }
                 resolve(result);
             }).catch(function(error) {
@@ -35,7 +40,11 @@ PowerBi.prototype = {
         return new Promise(function(resolve, reject) {
             that.get('datasets', {}).then(function(data) {
                 var foundDataset = {};
-                var values = JSON.parse(data.body).value;
+                
+                var values; // declaration needs to be wrapped in a try/catch as JSON.parse might fail
+                try { values = JSON.parse(data.body).value; }
+                catch (err) { return reject(err); }
+                
                 for(a = 0; a < values.length; a++) {
                     if(values[a].name == dataset) {
                         foundDataset = values[a];
@@ -70,10 +79,14 @@ PowerBi.prototype = {
                     that.get('datasets/' + result.dataset.id + '/tables', {}).then(function(data) {
                         //Variable to hold table info if found
                         var foundTable = {};
+                        
                         //Get result list of tables from request
-                        var values = JSON.parse(data.body).value;
+                        var values; // Declaration wrapped in try/catch
+                        try { values = JSON.parse(data.body).value; }
+                        catch (err) { return reject(err); }
+                        
                         //Loop through all tables in list
-                        for(a = 0; a < values.length; a++) {
+                        for(var a = 0; a < values.length; a++) {
                             if(values[a].name == table) { //If table name from method parameter exists in list
                                 //Set foundTable and end loop with break
                                 foundTable = values[a];

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   "devDependencies": {
     "gulp": "^3.9.0"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Kugghuset/apicBI.git"


### PR DESCRIPTION
Sometimes, JavaScript _seemingly_ random fails on JSON.parse, so all parsing should be wrapped in try/catch or other error handling blocks (Lodash provides the _.attempt(...) and _.isError(...) functions).
