### PR TITLE
Updates to AzureAuth

### DIFF
--- a/lib/azureAuth.js
+++ b/lib/azureAuth.js
@@ -1,5 +1,6 @@
 var AuthenticationContext = require('adal-node').AuthenticationContext
 var Promise = require('bluebird');
+var moment = require('moment');
 
 var AzureAuth = function() {
     this.authorityHostUrl = 'https://login.windows.net';
@@ -15,29 +16,62 @@ var AzureAuth = function() {
 
 AzureAuth.prototype = {
     token: 'default_token',
+    tokenExpiresOn: undefined,
     refreshToken: 'default_refresh_token',
+    /**
+     * Get token for Azure API
+     * @return {object} Promise of token or error
+     */
     getToken: function() {
+        //Check if an expiration date is set for the token and if its about to expire in 5 minutes
         var that = this;
         return new Promise(function(resolve, reject) {
-            that.context.acquireTokenWithUsernamePassword(that.resource, that.clientUsername, that.clientPassword, that.clientId, function(error, response) {
-                if (error) {
+            //If token expire is set and it is not about to expire (5 minute to expire)
+            if(that.tokenExpiresOn && moment().add(5, 'minutes').isBefore(that.tokenExpiresOn)) {
+                resolve({token: that.accessToken, refreshToken: that.refreshToken});
+                return;
+            //Else if token expire is set nad is about to expire (date is between expire date minus 5 minutes AND expire date)
+            } else if(that.tokenExpiresOn && moment().isBetween(that.tokenExpiresOn.subtract(5, 'minutes'), that.tokenExpiresOn)) {
+                that.getTokenRefresh().then(function(result) {
+                    resolve(result);
+                }).catch(function(error) {
                     reject(error);
-                    console.log('Error fetching access token for AZURE authentication: ' + error.stack);
+                });
+                return;
+            }
+            
+            //Token is not set or has expired, try to fetch new token
+            that.acquireToken(function(error, response) {
+                if (error) { //If any error occure, reject and end
+                    reject(error);
+                    return;
                 }
-
+                
+                //Set token, token expiration date and the refresh token
                 that.token = response.accessToken;
+                that.tokenExpiresOn = moment(new Date(response.expiresOn)).toDate();
                 that.refreshToken = response.refreshToken;
-
+                //Resolve with info
                 resolve({token: response.accessToken, refreshToken: response.refreshToken});
             });
         });
     },
+    /**
+     * Use refresh token to fetch new token
+     * @return {object} Promise of success or fail
+     */
     getTokenRefresh: function() {
         var that = this;
         return new Promise(function(resolve, reject) {
-            that.context.acquireTokenWithRefreshToken(that.refreshToken, that.clientId, null, function(error, response) {
+            that.acquireRefreshToken(function(error, response) {
                 if (error) {
-                    reject(error);
+                    that.getToken().then(function(result) {
+                        resolve(result);
+                    }).catch(function(error) {
+                        reject(error);
+                    });
+                    
+                    return;
                 }
 
                 that.token = response.accessToken;
@@ -46,6 +80,22 @@ AzureAuth.prototype = {
                 resolve({ token: response.accessToken, refreshToken: response.refreshToken });
             });
         });
+    },
+    /**
+     * adal-mode acquire token method
+     * @param {function} callback to use
+     * @return {object} acquire token return
+     */
+    acquireToken: function(callback) {
+        this.context.acquireTokenWithUsernamePassword(this.resource, this.clientUsername, this.clientPassword, this.clientId, callback);
+    },
+    /**
+     * adal-mode acquire refresh token method
+     * @param {function} callback to use
+     * @return {object} acquire refresh token return
+     */
+    acquireRefreshToken: function(callback) {
+        this.context.acquireTokenWithRefreshToken(this.refreshToken, this.clientId, null, callback);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "adal-node": "^0.1.17",
     "bluebird": "^3.0.6",
+    "moment": "^2.11.1",
     "node-env-file": "^0.1.8",
     "request": "^2.67.0"
   },


### PR DESCRIPTION
- Moved acquire token to own method
- Moved acquire refresh token to own method
- getToken now fetch new token if it's about to expire and if token exists and is invalid, fetch new one. If token is valid and not expired getToken will simply return the already existing token
- Using moment library to calculate token expiration difference
